### PR TITLE
Website menu redesigned

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,19 +7,35 @@
       <button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#exCollapsingNavbar" aria-controls="exCollapsingNavbar" aria-expanded="false" aria-label="Toggle navigation">
         &#9776;
       </button>
-      <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar">
-        <a class="nav-link" href="/activities/">Activities</a>
-        <a class="nav-link" href="/about/">About Clubs</a>
-        <a class="nav-link" href="/get-started/">Get Started</a>
-        <a class="nav-link" href="/resources/">Resources</a>
-        <a class="nav-link" href="/connect/">Connect</a>
-        <a class="nav-link" href="/report/#">Report</a>
-        <a class="nav-link" href="/faq/">FAQ</a>
+      
+      <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar">      
+        <!-- Activities link -->
+        <div class="nav-link">
+          <a class="nav-link" href="/activities/">Activities</a>
+        </div>
+        <!-- Clubs Corner Dropdown Menu -->
+        <div class="nav-link dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" data-toggle="dropdown">
+          Clubs Corner
+          </a>
+          <div class="dropdown-menu dropdown">
+            <a class="dropdown-item nav-link" href="/get-started/">Get Started</a>
+            <a class="dropdown-item nav-link" href="/resources/">Resources</a>
+            <a class="dropdown-item nav-link" href="/connect/">Connect</a>
+            <a class="dropdown-item nav-link" href="/report/#">Report</a>
+            <a class="dropdown-item nav-link" href="/faq/">FAQ</a>
+          </div>
+        </div>
+        <!-- About link -->
+        <div class="nav-link">
+            <a class="nav-link" href="/about/">About</a>
+        </div>      
       </div>
 
       <div id="tabzilla" class="hidden-lg-down">
         <a href="https://www.mozilla.org/" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
       </div>
+
     </div>
   </nav>
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -148,6 +148,34 @@ nav a:hover {
     margin-top: 20px;
 }
 
+/* CSS for dropdown menu */
+.dropdown .dropdown-menu {
+    -webkit-transition: all 0.5s;
+    -moz-transition: all 0.5s;
+    -ms-transition: all 0.5s;
+    -o-transition: all 0.5s;
+    transition: all 0.5s;
+
+    max-height: 0;
+    display: block;
+    overflow: hidden;
+    opacity: 0;
+}
+
+.dropdown.open .dropdown-menu {
+    max-height: 200px;
+    opacity: 1;
+}
+
+nav .dropdown-menu {
+    background-color: #3BBA99 !important;
+}
+
+nav .dropdown-menu .dropdown-item:hover {
+    background-color: black !important;
+    color:white !important;
+}
+/* -------------------- */
 @media all and (min-width: 992px) {
     .navbar-toggleable-md {
         display: inline-block !important;


### PR DESCRIPTION
Closes #96

In this Pull request following changes have been made:
1. Rearranged the top website menu to Activities | Clubs Corner | About :
original website menu:
![original_menu](https://user-images.githubusercontent.com/31198893/46336877-a7819600-c649-11e8-9589-c19a39bc7d4e.png)
New arranged website menu:
![new_menu](https://user-images.githubusercontent.com/31198893/46336897-b6684880-c649-11e8-8110-0c60b2d27ce9.png)
Mobile version of the new menu:
![new_mobile_menu](https://user-images.githubusercontent.com/31198893/46336906-bff1b080-c649-11e8-9e1c-b8c8184353d6.png)
2. Transitions added to the dropdown menu to make it load smoothly