### PR TITLE
Header navigation update

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,13 +8,31 @@
         &#9776;
       </button>
       <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar">
-        <a class="nav-link" href="/activities/">Activities</a>
-        <a class="nav-link" href="/about/">About Clubs</a>
-        <a class="nav-link" href="/get-started/">Get Started</a>
-        <a class="nav-link" href="/resources/">Resources</a>
-        <a class="nav-link" href="/connect/">Connect</a>
-        <a class="nav-link" href="/report/#">Report</a>
-        <a class="nav-link" href="/faq/">FAQ</a>
+
+        <ul class="navbar-nav">
+      <li class="nav-item">
+         <a class="nav-link" href="/activities/">Activities</a>
+      </li>
+      
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+         Club's Corner
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/about/">About Clubs</a>
+          <a class="dropdown-item" href="/get-started/">Get Started</a>
+          <a class="dropdown-item" href="/resources/">Resources</a>
+          <a class="dropdown-item" href="/connect/">Connect</a>
+          <a class="dropdown-item" href="/report/#">Report</a>
+          <a class="dropdown-item" href="/faq/">FAQ</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/about/">About</a>
+      </li>
+    </ul>
+       
+        
       </div>
 
       <div id="tabzilla" class="hidden-lg-down">

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -638,3 +638,34 @@ a.btn-primary-activities {
 .headersleft h3 {
   text-align: left;
 }
+
+
+.navbar-nav .nav-item {
+    font-size: inherit;
+    list-style: none;
+
+}
+
+.dropdown-menu {
+    background-color: #3bba99;
+    
+}
+
+.dropdown-menu a:hover {
+    background-color: #3bba99;
+    
+}
+
+
+.navbar-toggleable-md {
+    margin-top: 35px;
+}
+
+.navbar-nav .nav-item + .nav-item {
+    margin-left: 0;
+}
+
+.navbar-toggleable-md ul{
+    margin-left: 0px;
+}
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6341503/46570755-534d1d80-c98b-11e8-86bf-c5f5c3ada819.png)

navigation menu has been rearranged and 
**Get Started | Resources | Connect | Report | FAQ** is now under Club's corner