### PR TITLE
Mozilla campus club challenge: Resolved navigation bar issue #96

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,26 +1,94 @@
 <header class="site-header">
+ <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+ 
+ <style>
+    .dropdown-menu{
+        background: #3BBA99;    
+    }
+    .dropdown-item:hover{
+        background-color: rgb(0, 128, 79);    
+    }
+  </style>
+    
+    
+  <script>
 
-  <nav class="navbar">
-    <div class="container">
-      <a class="navbar-brand" href="/"><img src="/static/img/clubs.svg" alt="{{ site.title | escape }}"></a>
+    //Event handler to either show new navigation bar or display a drop down menu when cursor is on the  Club's Corner link
+    function showClubCornerNavBar()
+    {
+        var isNavBarCollapsed = $("#navBarCollapseButton").is(":visible");
+	//Display dropdown menu
+        if(isNavBarCollapsed)
+        {
+          document.getElementById("clubCornerMenu").hidden=false;
+        }
+	//Display a new navigation bar
+        else
+        {
+          document.getElementById("clubCornerMenu").hidden=true;
+          document.getElementById("clubCornerNavig").innerHTML='<nav class="navbar" onmousout="mouseOutClubCornerNavBar()"> \
+              <div class="container"  > \
+                <div class="collapse navbar-toggleable-md" id="clubCorner_parent1Div"> \
+                  <a class="nav-link" href="/get-started/">Get Started</a> \
+                  <a class="nav-link" href="/resources/">Resources</a> \
+                  <a class="nav-link" href="/connect/">Connect</a> \
+                  <a class="nav-link" href="/report/#">Report</a> \
+                  <a class="nav-link" href="/faq/">FAQ</a> \
+                </div>  \
+              </div> \
+            </nav>';
+        }
+    }
 
-      <button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#exCollapsingNavbar" aria-controls="exCollapsingNavbar" aria-expanded="false" aria-label="Toggle navigation">
+    //Event handler when cursor moves away from the navigation bar below Club's Corner link
+    function mouseOutClubCornerNavBar(e)
+    {
+      var relTarg,relTargID, relTargName;
+      relTarg = e.toElement || e.relatedTarget;
+      relTargID=relTarg.id;
+      relTargName=relTarg.nodeName;
+      if(relTargID!="clubCorner_parent1Div" && relTargName!="A" )
+      {
+        hideClubCornerNavBar();
+      }
+    }
+
+    //Event handler to hide the navigation bar under Club's Corner link
+    function hideClubCornerNavBar()
+    {
+      document.getElementById("clubCornerNavig").innerHTML="";
+    }
+  </script>
+
+  <nav class="navbar" >
+    <div class="container" id="upperNavButton">
+      <a class="navbar-brand" href="/"><img src="/static/img/clubs.svg" alt="Mozilla Campus Clubs"></a>
+      <button id="navBarCollapseButton" class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#exCollapsingNavbar" aria-controls="exCollapsingNavbar" aria-expanded="false" aria-label="Toggle navigation">
         &#9776;
       </button>
-      <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar">
-        <a class="nav-link" href="/activities/">Activities</a>
-        <a class="nav-link" href="/about/">About Clubs</a>
-        <a class="nav-link" href="/get-started/">Get Started</a>
-        <a class="nav-link" href="/resources/">Resources</a>
-        <a class="nav-link" href="/connect/">Connect</a>
-        <a class="nav-link" href="/report/#">Report</a>
-        <a class="nav-link" href="/faq/">FAQ</a>
+      <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar" >
+        <a class="nav-link" href="/activities/" onmouseover="hideClubCornerNavBar()">Activities</a>
+        <div class="nav-link dropdown">
+          <a  data-toggle="dropdown"  href="#" class="nav-link" onmouseover="showClubCornerNavBar()">Club's Corner</a>
+            <div hidden id="clubCornerMenu" class="dropdown-menu" aria-labelledby="clubCornerLink">
+              <a class="dropdown-item" href="/get-started/">Get Started</a>
+              <a class="dropdown-item" href="/resources/">Resources</a>
+              <a class="dropdown-item" href="/connect/">Connect</a>
+              <a class="dropdown-item" href="/report/">Report</a>
+              <a class="dropdown-item " href="/faq/">FAQ</a>
+            </div> 
+        </div>
+        <a class="nav-link" href="/about/" onmouseover="hideClubCornerNavBar()">About Clubs</a>
       </div>
-
       <div id="tabzilla" class="hidden-lg-down">
         <a href="https://www.mozilla.org/" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
       </div>
     </div>
   </nav>
 
+  <div id="clubCornerNavig" onmouseout="mouseOutClubCornerNavBar(event)"> 
+  </div>
+
 </header>
+
+


### PR DESCRIPTION
Resolved Issue #96

### Description
The navigation bar will now appear as:
Activities | Club's Corner | About

where under "Club's Corner" the following sub-pages will be displayed:
Get Started | Resources | Connect | Report | FAQ

+ When the main navigation bar is not collapsed, upon hovering over "Club's Corner" a new navigation bar will be displayed. 
+ When the main navigation bar is collapsed, then a drop-down menu will appear when "Club' Corner" is clicked.

### Implementation Details
+ Apart from HTML code, I have also added a Js script and two CSS class definitons. The script contains the event handlers when cursor clicks or hovers over "Club's Corner". The latter is for styling the drop-down menu and drop-down menu items. 

+ When the main navigation bar is not collapsed, then I have added event handlers which upon hovering over "Club's Corner" will fill in an empty "\<div\>" section with HTML code to display a new navigation bar below the main one and set the 'hidden' attribute to 'false' for the tag that displays the drop-down menu on clicking on "Club's Corner".

+ When the main navigation bar is collapsed, then I have set the 'hidden' attribute to 'true' for the tag that displays the drop-down menu on clicking on "Club's Corner".

+ *Note: The drop-down menu cannot be formed to the left of "Club's Corner" as it is embedded within a "nav-bar". This issue has been resolved in the latest version of Bootstrap.

### Screenshots 
![beforecrop](https://user-images.githubusercontent.com/26901564/46602257-3f312980-cb0d-11e8-951a-01e01bddee9f.jpg)
<i>Screenshot-1: When main navigation bar is not collapsed.</i> <br> <br>
![aftercrop](https://user-images.githubusercontent.com/26901564/46602261-435d4700-cb0d-11e8-8e3e-0085aaec50f3.jpg)
<i>Screenshot-2: When main navigation bar is not collapsed and mouse has hovered over "Club's Corner".</i> <br> <br>
![before2crop](https://user-images.githubusercontent.com/26901564/46602264-45bfa100-cb0d-11e8-9424-339a2c467b8c.jpg)
<i>Screenshot-3: When main navigation bar is collapsed. </i> <br> <br>
![after2crop](https://user-images.githubusercontent.com/26901564/46602268-47896480-cb0d-11e8-943e-92d744410999.jpg)
<i>Screenshot-4: When main navigation bar is collapsed and cursor has clicked on "Club's Corner".</i> <br> 

### How to run
Build the project as usual and the new header will be added to all the web-pages automatically.

### Checklist
- [x] Site builds.
- [x] Changes are tested.
- [x] Followed the Contributing guidelines.
- [x] Checked for merge conflicts.

<!-- Delete all the unnecessary / inapplicable text from the template -->
