### PR TITLE
Fix typo cluv -> club

### DIFF
--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -49,7 +49,7 @@ ref: faq
                 <div id="collapseOne" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p>
-                        Under the resources page you can find a lot and useful guides and tools for how to start a new club in your campus. The Mozilla Campus Clubs is just a network of established clubs that care about Open Source. Other than the availabe resources, we don't provide any further support for starting a new cluv in your campus. 
+                        Under the resources page you can find a lot and useful guides and tools for how to start a new club in your campus. The Mozilla Campus Clubs is just a network of established clubs that care about Open Source. Other than the availabe resources, we don't provide any further support for starting a new club in your campus. 
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
https://campus.mozilla.community/faq/ has a typo in point 2 last line. Instead of club its written cluv. 
This PR fixes that (#238)